### PR TITLE
[develop ← feat/chat] ✨ 웹소켓 기반 간단 채팅 구현 및 기본 도메인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.kr'
@@ -9,44 +9,44 @@ version = '0.0.1-SNAPSHOT'
 description = 'KNU-CAMPUS-SERVER'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
 
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
     // * SpringBoot
     implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // * Database
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // * Lombok
     compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     // * Password Encoder
     implementation 'org.springframework.security:spring-security-crypto:6.4.4'
 
     // * Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // * Junit
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // * JWT
     compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
@@ -59,8 +59,12 @@ dependencies {
     // * WebSocket
     implementation 'org.springframework:spring-websocket'
     implementation 'org.springframework:spring-messaging'
+
+    // *  Oracle
+    implementation 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
+
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ java {
 }
 
 configurations {
+
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -54,6 +55,10 @@ dependencies {
 
     // * SpringDoc
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
+    // * WebSocket
+    implementation 'org.springframework:spring-websocket'
+    implementation 'org.springframework:spring-messaging'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kr/knucampus/application/chat/ChatService.java
+++ b/src/main/java/com/kr/knucampus/application/chat/ChatService.java
@@ -1,0 +1,30 @@
+package com.kr.knucampus.application.chat;
+
+import com.kr.knucampus.presentation.chat.dto.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void sendMessage(ChatMessage message) {
+        String destination = "/topic/chatroom/" + message.roomId();
+        messagingTemplate.convertAndSend(destination, message);
+        log.info("Sent message to {}: {}", destination, message.content());
+    }
+
+    public void handleEnter(ChatMessage message) {
+        ChatMessage enterMessage = ChatMessage.enter(message.roomId(), message.senderName());
+        messagingTemplate.convertAndSend("/topic/chatroom/" + message.roomId(), enterMessage);
+    }
+
+    public void handleLeave(ChatMessage message) {
+        ChatMessage leaveMessage = ChatMessage.leave(message.roomId(), message.senderName());
+        messagingTemplate.convertAndSend("/topic/chatroom/" + message.roomId(), leaveMessage);
+    }
+}

--- a/src/main/java/com/kr/knucampus/domain/baseentity/BaseEntity.java
+++ b/src/main/java/com/kr/knucampus/domain/baseentity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.kr.knucampus.domain.baseentity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/kr/knucampus/domain/chatroom/ChatRoom.java
+++ b/src/main/java/com/kr/knucampus/domain/chatroom/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.kr.knucampus.domain.chatroom;
 
+import com.kr.knucampus.domain.baseentity.BaseEntity;
 import com.kr.knucampus.domain.matchingsession.MatchingSession;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatRoom {
+public class ChatRoom extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kr/knucampus/domain/chatroom/ChatRoom.java
+++ b/src/main/java/com/kr/knucampus/domain/chatroom/ChatRoom.java
@@ -1,0 +1,36 @@
+package com.kr.knucampus.domain.chatroom;
+
+import com.kr.knucampus.domain.matchingsession.MatchingSession;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", unique = true)
+    private MatchingSession session;
+
+    private ChatRoom(MatchingSession session) {
+        this.session = session;
+    }
+
+    public static ChatRoom create(MatchingSession session) {
+        return new ChatRoom(session);
+    }
+}
+

--- a/src/main/java/com/kr/knucampus/domain/group/Group.java
+++ b/src/main/java/com/kr/knucampus/domain/group/Group.java
@@ -1,0 +1,27 @@
+package com.kr.knucampus.domain.group;
+
+import com.kr.knucampus.domain.student.Gender;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+}
+

--- a/src/main/java/com/kr/knucampus/domain/group/Group.java
+++ b/src/main/java/com/kr/knucampus/domain/group/Group.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,5 +24,10 @@ public class Group {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @Builder
+    public Group(Long id, Gender gender) {
+        this.id = id;
+        this.gender = gender;
+    }
 }
 

--- a/src/main/java/com/kr/knucampus/domain/group/Group.java
+++ b/src/main/java/com/kr/knucampus/domain/group/Group.java
@@ -1,5 +1,6 @@
 package com.kr.knucampus.domain.group;
 
+import com.kr.knucampus.domain.baseentity.BaseEntity;
 import com.kr.knucampus.domain.student.Gender;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Group {
+public class Group extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kr/knucampus/domain/matchingsession/MatchingSession.java
+++ b/src/main/java/com/kr/knucampus/domain/matchingsession/MatchingSession.java
@@ -1,5 +1,6 @@
 package com.kr.knucampus.domain.matchingsession;
 
+import com.kr.knucampus.domain.baseentity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MatchingSession {
+public class MatchingSession extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kr/knucampus/domain/matchingsession/MatchingSession.java
+++ b/src/main/java/com/kr/knucampus/domain/matchingsession/MatchingSession.java
@@ -1,0 +1,34 @@
+package com.kr.knucampus.domain.matchingsession;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MatchingType type;
+
+
+    private MatchingSession(MatchingType type) {
+        this.type = type;
+    }
+
+    public static MatchingSession create(MatchingType type) {
+        return new MatchingSession(type);
+    }
+}
+

--- a/src/main/java/com/kr/knucampus/domain/matchingsession/MatchingType.java
+++ b/src/main/java/com/kr/knucampus/domain/matchingsession/MatchingType.java
@@ -1,0 +1,5 @@
+package com.kr.knucampus.domain.matchingsession;
+
+public enum MatchingType {
+    ONE_TO_ONE, THREE_TO_THREE
+}

--- a/src/main/java/com/kr/knucampus/domain/message/Message.java
+++ b/src/main/java/com/kr/knucampus/domain/message/Message.java
@@ -1,0 +1,43 @@
+package com.kr.knucampus.domain.message;
+
+import com.kr.knucampus.domain.chatroom.ChatRoom;
+import com.kr.knucampus.domain.student.Student;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message {
+
+    @Id
+    @Column(name = "message_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student sender;
+
+    @Column(nullable = false, columnDefinition = "CLOB")
+    private String content;
+
+    @Builder
+    public Message(ChatRoom chatRoom, Student sender, String content, LocalDateTime createdAt) {
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/kr/knucampus/domain/message/Message.java
+++ b/src/main/java/com/kr/knucampus/domain/message/Message.java
@@ -1,5 +1,6 @@
 package com.kr.knucampus.domain.message;
 
+import com.kr.knucampus.domain.baseentity.BaseEntity;
 import com.kr.knucampus.domain.chatroom.ChatRoom;
 import com.kr.knucampus.domain.student.Student;
 import jakarta.persistence.Column;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Message {
+public class Message extends BaseEntity {
 
     @Id
     @Column(name = "message_id")

--- a/src/main/java/com/kr/knucampus/domain/student/Gender.java
+++ b/src/main/java/com/kr/knucampus/domain/student/Gender.java
@@ -1,0 +1,3 @@
+package com.kr.knucampus.domain.student;
+
+public enum Gender {M, F}

--- a/src/main/java/com/kr/knucampus/domain/student/Mbti.java
+++ b/src/main/java/com/kr/knucampus/domain/student/Mbti.java
@@ -1,0 +1,7 @@
+package com.kr.knucampus.domain.student;
+
+public enum Mbti {
+    ISTJ, ISFJ, INFJ, INTJ, ISTP, ISFP, INFP, INTP,
+    ESTP, ESFP, ENFP, ENTP, ESTJ, ESFJ, ENFJ, ENTJ;
+}
+

--- a/src/main/java/com/kr/knucampus/domain/student/Student.java
+++ b/src/main/java/com/kr/knucampus/domain/student/Student.java
@@ -1,5 +1,6 @@
 package com.kr.knucampus.domain.student;
 
+import com.kr.knucampus.domain.baseentity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Student {
+public class Student extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/kr/knucampus/domain/student/Student.java
+++ b/src/main/java/com/kr/knucampus/domain/student/Student.java
@@ -1,0 +1,51 @@
+package com.kr.knucampus.domain.student;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String studentNumber;
+    private int age;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Mbti mbti;
+
+    @Lob
+    private String profile;
+
+    private String department;
+
+    @Builder
+    public Student(String studentNumber, int age, Gender gender, String name, Mbti mbti, String profile,
+                   String department) {
+        this.studentNumber = studentNumber;
+        this.age = age;
+        this.gender = gender;
+        this.name = name;
+        this.mbti = mbti;
+        this.profile = profile;
+        this.department = department;
+    }
+}

--- a/src/main/java/com/kr/knucampus/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kr/knucampus/global/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.kr.knucampus.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.enableSimpleBroker("/topic", "/queue");
+    }
+
+}

--- a/src/main/java/com/kr/knucampus/presentation/chat/ChatController.java
+++ b/src/main/java/com/kr/knucampus/presentation/chat/ChatController.java
@@ -1,0 +1,38 @@
+package com.kr.knucampus.presentation.chat;
+
+import com.kr.knucampus.presentation.chat.dto.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    @MessageMapping("/sendMessage")
+    @SendTo("/topic/chatroom/{roomId}")
+    public String sendMessage(ChatMessage message) {
+        // 메세지 가공, 저장 로직 필요(Redis, DB 등)
+        log.info("보낸 사람: {}, 내용: {}", message.senderName(), message.content());
+        return message.content();
+    }
+
+    @MessageMapping("/enter")
+    @SendTo("/topic/chatroom/{roomId}")
+    public ChatMessage enter(ChatMessage message) {
+        // 입장 처리
+        return message;
+    }
+
+    @MessageMapping("/leave")
+    @SendTo("/topic/chatroom/{roomId}")
+    public ChatMessage leave(ChatMessage message) {
+        // 퇴장 처리
+        return message;
+    }
+}

--- a/src/main/java/com/kr/knucampus/presentation/chat/ChatController.java
+++ b/src/main/java/com/kr/knucampus/presentation/chat/ChatController.java
@@ -1,38 +1,31 @@
 package com.kr.knucampus.presentation.chat;
 
+import com.kr.knucampus.application.chat.ChatService;
 import com.kr.knucampus.presentation.chat.dto.ChatMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Controller;
 
 @Slf4j
-@RestController
-@RequestMapping("/v1/chat")
+@Controller
 @RequiredArgsConstructor
 public class ChatController {
+    private final ChatService chatService;
 
     @MessageMapping("/sendMessage")
-    @SendTo("/topic/chatroom/{roomId}")
-    public String sendMessage(ChatMessage message) {
-        // 메세지 가공, 저장 로직 필요(Redis, DB 등)
-        log.info("보낸 사람: {}, 내용: {}", message.senderName(), message.content());
-        return message.content();
+    public void sendMessage(ChatMessage message) {
+        log.info("Received message: {}", message.content());
+        chatService.sendMessage(message);
     }
 
     @MessageMapping("/enter")
-    @SendTo("/topic/chatroom/{roomId}")
-    public ChatMessage enter(ChatMessage message) {
-        // 입장 처리
-        return message;
+    public void enter(ChatMessage message) {
+        chatService.handleEnter(message);
     }
 
     @MessageMapping("/leave")
-    @SendTo("/topic/chatroom/{roomId}")
-    public ChatMessage leave(ChatMessage message) {
-        // 퇴장 처리
-        return message;
+    public void leave(ChatMessage message) {
+        chatService.handleLeave(message);
     }
 }

--- a/src/main/java/com/kr/knucampus/presentation/chat/dto/ChatMessage.java
+++ b/src/main/java/com/kr/knucampus/presentation/chat/dto/ChatMessage.java
@@ -1,0 +1,9 @@
+package com.kr.knucampus.presentation.chat.dto;
+
+public record ChatMessage(
+        Long roomId,
+        String senderName,
+        String content,
+        MessageType type
+) {
+}

--- a/src/main/java/com/kr/knucampus/presentation/chat/dto/ChatMessage.java
+++ b/src/main/java/com/kr/knucampus/presentation/chat/dto/ChatMessage.java
@@ -6,4 +6,15 @@ public record ChatMessage(
         String content,
         MessageType type
 ) {
+    public static ChatMessage of(Long roomId, String senderName, String content, MessageType type) {
+        return new ChatMessage(roomId, senderName, content, type);
+    }
+
+    public static ChatMessage enter(Long roomId, String senderName) {
+        return new ChatMessage(roomId, senderName, senderName + "님이 입장했습니다.", MessageType.ENTER);
+    }
+
+    public static ChatMessage leave(Long roomId, String senderName) {
+        return new ChatMessage(roomId, senderName, senderName + "님이 퇴장했습니다.", MessageType.LEAVE);
+    }
 }

--- a/src/main/java/com/kr/knucampus/presentation/chat/dto/MessageType.java
+++ b/src/main/java/com/kr/knucampus/presentation/chat/dto/MessageType.java
@@ -1,5 +1,5 @@
 package com.kr.knucampus.presentation.chat.dto;
 
 public enum MessageType {
-    ENTER, TALK, LEAVE
+    ENTER, CHAT, LEAVE
 }

--- a/src/main/java/com/kr/knucampus/presentation/chat/dto/MessageType.java
+++ b/src/main/java/com/kr/knucampus/presentation/chat/dto/MessageType.java
@@ -1,0 +1,5 @@
+package com.kr.knucampus.presentation.chat.dto;
+
+public enum MessageType {
+    ENTER, TALK, LEAVE
+}


### PR DESCRIPTION
- WebSocket STOMP로 SimpleBroker를 통한 간단 채팅 기능 구현
- 프로젝트 기본 도메인들 구현


### 해야할 것
- 채팅 메세지를 레디스로 보관 후 50개씩 받고 DB 영속화 
- JWT와 연동하여 사용자 검증 및 1:1, 3:3 채팅방 기능 추가